### PR TITLE
fix: update title and description for new name

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,6 +1,6 @@
-WiFiScanner is an App for analysing the WiFi networks in range.
+WLANScanner is an App for analysing the WiFi networks in range.
 
-WiFiScanner features a list view and diagram views for the 2.4 GHz, 5 GHz and 6 GHz band. Filter, sorting options and other settings are also available.
+WLANScanner features a list view and diagram views for the 2.4 GHz, 5 GHz and 6 GHz band. Filter, sorting options and other settings are also available.
 
 Open source. No Ads.
 

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-WiFiScanner
+WLANScanner


### PR DESCRIPTION
Fixing long description and title for fastlane which wasn't updated, and cause F-droid to still use old name despite updated metadata (see https://f-droid.org/fr/packages/org.bitbatzen.wlanscanner/ for example).

Also, out of curiosity on my end, why the name change?

And little nitpick from me, but I saw in the short description it uses "Analyse", which is generally GB English while US rather write "Analyze", but it's put in the `en_US` fastlane locale.
But you might prefer that spelling and don't want to bother separating `en_US` and `en_GB` :)